### PR TITLE
update dashboard annotations for latest dashboards provisioning

### DIFF
--- a/management-clusters/golem/organizations/presales-demo/workload-clusters/presales-demo-gitops/mapi/apps/podinfo/dashboard.yaml
+++ b/management-clusters/golem/organizations/presales-demo/workload-clusters/presales-demo-gitops/mapi/apps/podinfo/dashboard.yaml
@@ -1,4 +1,4 @@
-gpiVersion: v1
+apiVersion: v1
 data:
   podinfo-demo-dashboard.json: |-
     {

--- a/management-clusters/golem/organizations/presales-demo/workload-clusters/presales-demo-gitops/mapi/apps/podinfo/dashboard.yaml
+++ b/management-clusters/golem/organizations/presales-demo/workload-clusters/presales-demo-gitops/mapi/apps/podinfo/dashboard.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+gpiVersion: v1
 data:
   podinfo-demo-dashboard.json: |-
     {
@@ -1564,8 +1564,8 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    ## Define the directory in grafana where the dashboard will be added to the grafana container
-    k8s-sidecar-target-directory: /var/lib/grafana/dashboards/customer
+    ## Load dashboard in "Shared Org" grafana organization
+    observability.giantswarm.io/organization: "Shared Org"
   labels:
     ## Tell grafana to load this configmap as a dashboard
     app.giantswarm.io/kind: dashboard


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3696

This PR updates the dashboard for the multi-tenant dashboards provisioning.

Note: the new annotations will work on CAPI clusters, but not on vintage clusters.